### PR TITLE
Implement last login

### DIFF
--- a/module/Member/config/services.yml
+++ b/module/Member/config/services.yml
@@ -29,3 +29,9 @@ services:
     Rox\Member\Service\MemberService:
         class: Rox\Member\Service\MemberService
         arguments: ['@Rox\Auth\Factory\EncoderFactory']
+
+    Rox\Member\Listener\LastLoginListener:
+        class: Rox\Member\Listener\LastLoginListener
+        autowire: true
+        tags:
+            - { name: kernel.event_listener, event: security.authentication.success, method: onAuthSuccess }

--- a/module/Member/src/Listener/LastLoginListener.php
+++ b/module/Member/src/Listener/LastLoginListener.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rox\Member\Listener;
+
+use Rox\Member\Model\Member;
+use Symfony\Component\Security\Core\Event\AuthenticationEvent;
+
+class LastLoginListener
+{
+    public function onAuthSuccess(AuthenticationEvent $e)
+    {
+        $user = $e->getAuthenticationToken()->getUser();
+
+        if (!$user instanceof Member) {
+            return;
+        }
+
+        $user->LastLogin = $user->freshTimestamp();
+
+        $user->save();
+    }
+}

--- a/module/Member/templates/profile/cards/hosting.html.twig
+++ b/module/Member/templates/profile/cards/hosting.html.twig
@@ -48,7 +48,9 @@
 
     <div class="media m-t-0">
         <div class="media-body summary">
-            <small><i><span class="gray">Last login: {{ member.LastLogin.diffForHumans }}</span></i><br></small>
+            <small><i><span class="gray">
+                {{ 'Last login:' | trans }} {{ member.LastLogin ? member.LastLogin.diffForHumans : 'never' | trans }}
+            </span></i><br></small>
         </div>
     </div>
 </div>


### PR DESCRIPTION
security.authentication.success listener and fix 'last login' info on profile when user has never logged in.